### PR TITLE
🚀 delete confirm, cancel api & update change status one both list api

### DIFF
--- a/backend/abba/src/main/java/com/zon/abba/order/controller/OrderController.java
+++ b/backend/abba/src/main/java/com/zon/abba/order/controller/OrderController.java
@@ -3,9 +3,7 @@ package com.zon.abba.order.controller;
 import com.zon.abba.common.request.RequestList;
 import com.zon.abba.common.response.ResponseBody;
 import com.zon.abba.common.response.ResponseListBody;
-import com.zon.abba.order.request.OrderDetailIdRequest;
-import com.zon.abba.order.request.OrderIdRequest;
-import com.zon.abba.order.request.RegisterOrderRequest;
+import com.zon.abba.order.request.*;
 import com.zon.abba.order.response.DetailAdminOrderResponse;
 import com.zon.abba.order.response.DetailOrderResponse;
 import com.zon.abba.order.service.OrderService;
@@ -54,11 +52,20 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PostMapping("/cancel")
-    @Operation(summary = "주문 취소", description = "주문한 상품을 취소할 수 있다.")
-    public ResponseEntity<Object> cancelOrder(@RequestBody List<OrderDetailIdRequest> request){
+    @PostMapping("/list/change/status")
+    @Operation(summary = "주문 리스트 상태 바꾸기", description = "여러개의 주문 내역의 상태를 바꿀 수 있다.")
+    public ResponseEntity<Object> cancelOrder(@RequestBody ChangeStatusListRequest request){
 
-        ResponseBody response = orderService.cancelOrder(request);
+        ResponseBody response = orderService.changeOrderListStatus(request);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PostMapping("/change/status")
+    @Operation(summary = "하나의 주문 상태 바꾸기", description = "하나의 주문 내역의 상태를 바꿀 수 있다.")
+    public ResponseEntity<Object> confirmOrder(@RequestBody ChangeStatusRequest request){
+
+        ResponseBody response = orderService.changeOrderStatus(request);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
@@ -68,15 +75,6 @@ public class OrderController {
     public ResponseEntity<Object> deleteOrder(@RequestBody List<OrderDetailIdRequest> request){
 
         ResponseBody response = orderService.deleteOrder(request);
-
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
-    @PostMapping("/confirm")
-    @Operation(summary = "구매 확정", description = "고객이 상품을 받은 이후 확정할 수 있다.")
-    public ResponseEntity<Object> confirmOrder(@RequestBody OrderDetailIdRequest request){
-
-        ResponseBody response = orderService.confirmOrder(request);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/backend/abba/src/main/java/com/zon/abba/order/request/ChangeStatusListRequest.java
+++ b/backend/abba/src/main/java/com/zon/abba/order/request/ChangeStatusListRequest.java
@@ -1,0 +1,20 @@
+package com.zon.abba.order.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChangeStatusListRequest {
+    @JsonProperty("orderDetailIDs")
+    private List<OrderDetailIdRequest> orderDetailIDs;
+    @JsonProperty("status")
+    private Integer status;
+}

--- a/backend/abba/src/main/java/com/zon/abba/order/request/ChangeStatusRequest.java
+++ b/backend/abba/src/main/java/com/zon/abba/order/request/ChangeStatusRequest.java
@@ -1,0 +1,18 @@
+package com.zon.abba.order.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChangeStatusRequest {
+    @JsonProperty("orderDetailID")
+    private String orderDetailID;
+    @JsonProperty("status")
+    private Integer status;
+}

--- a/backend/abba/src/main/java/com/zon/abba/order/service/OrderService.java
+++ b/backend/abba/src/main/java/com/zon/abba/order/service/OrderService.java
@@ -17,9 +17,7 @@ import com.zon.abba.order.mapping.OrderList;
 import com.zon.abba.order.mapping.OrderedProduct;
 import com.zon.abba.order.repository.OrderDetailRepository;
 import com.zon.abba.order.repository.OrderRepository;
-import com.zon.abba.order.request.OrderDetailIdRequest;
-import com.zon.abba.order.request.OrderIdRequest;
-import com.zon.abba.order.request.RegisterOrderRequest;
+import com.zon.abba.order.request.*;
 import com.zon.abba.order.response.DetailAdminOrderResponse;
 import com.zon.abba.order.response.DetailOrderResponse;
 import com.zon.abba.product.entity.Product;
@@ -212,16 +210,16 @@ public class OrderService {
     }
 
     @Transactional
-    public ResponseBody cancelOrder(List<OrderDetailIdRequest> request){
+    public ResponseBody changeOrderListStatus(ChangeStatusListRequest request){
         logger.info("주문을 취소합니다.");
 
-        List<String> ids = request.stream()
+        List<String> ids = request.getOrderDetailIDs().stream()
                 .map(OrderDetailIdRequest::getOrderDetailID)
                 .toList();
         List<OrderDetail> list = orderDetailRepository.findByOrderDetailIds(ids);
 
         // 400 : 취소
-        list.forEach(od -> od.setStatus(400));
+        list.forEach(od -> od.setStatus(request.getStatus()));
 
         // 업데이트 내용 저장
         orderDetailRepository.saveAll(list);
@@ -250,14 +248,14 @@ public class OrderService {
     }
 
     @Transactional
-    public ResponseBody confirmOrder(OrderDetailIdRequest request){
+    public ResponseBody changeOrderStatus(ChangeStatusRequest request){
         logger.info("구매를 확정합니다.");
 
         OrderDetail orderDetail = orderDetailRepository.findById(request.getOrderDetailID())
                 .orElseThrow(() -> new NoDataException("없는 주문 목록입니다."));
 
         // 삭제 처리
-        orderDetail.setStatus(500);
+        orderDetail.setStatus(request.getStatus());
 
         // 업데이트 내용 저장
         orderDetailRepository.save(orderDetail);


### PR DESCRIPTION
기존의 order cancel과 order confirm api를 삭제함.
이후 orderDetailIDs를 리스트로 받아 status를 바꾸는 api 와
하나의 orderDetailID만 받아 status를 바꾸는 api를 추가함